### PR TITLE
Improving BitmapData.draw performance (in dispose Image mode)

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -222,6 +222,7 @@ class BitmapData implements IBitmapDrawable
 	@:noCompletion private var __worldAlpha:Float;
 	@:noCompletion private var __worldColorTransform:ColorTransform;
 	@:noCompletion private var __worldTransform:Matrix;
+	@:noCompletion private var __renderer:OpenGLRenderer;
 
 	/**
 		Creates a BitmapData object with a specified width and height. If you specify a value for
@@ -918,27 +919,35 @@ class BitmapData implements IBitmapDrawable
 				_colorTransform.__combine(colorTransform);
 			}
 
-			var renderer = new OpenGLRenderer(Lib.current.stage.context3D, this);
-			renderer.__allowSmoothing = smoothing;
-			renderer.__pixelRatio = #if openfl_disable_hdpi 1 #else Lib.current.stage.window.scale #end;
-			renderer.__overrideBlendMode = blendMode;
+			if (__renderer == null)
+			{
+				__renderer = new OpenGLRenderer(Lib.current.stage.context3D, this);
+			}
+			else
+			{
+				@:privateAccess __renderer.__cleanup();
+				__renderer.setShader(@:privateAccess __renderer.__defaultShader);
+			}
+			__renderer.__allowSmoothing = smoothing;
+			__renderer.__pixelRatio = #if openfl_disable_hdpi 1 #else Lib.current.stage.window.scale #end;
+			__renderer.__overrideBlendMode = blendMode;
 
-			renderer.__worldTransform = transform;
-			renderer.__worldAlpha = 1 / source.__worldAlpha;
-			renderer.__worldColorTransform = _colorTransform;
+			__renderer.__worldTransform = transform;
+			__renderer.__worldAlpha = 1 / source.__worldAlpha;
+			__renderer.__worldColorTransform = _colorTransform;
 
-			renderer.__resize(width, height);
+			__renderer.__resize(width, height);
 
 			if (clipRect != null)
 			{
-				renderer.__pushMaskRect(clipRect, clipMatrix);
+				__renderer.__pushMaskRect(clipRect, clipMatrix);
 			}
 
-			__drawGL(source, renderer);
+			__drawGL(source, __renderer);
 
 			if (clipRect != null)
 			{
-				renderer.__popMaskRect();
+				__renderer.__popMaskRect();
 				Matrix.__pool.release(clipMatrix);
 			}
 		}


### PR DESCRIPTION
1. Referencing the OpenGLRenderer renderer eliminates the need for reconstruction and reduces the cost of initializing the Shader.

2. Set default shaders for existing OpenGLRenderer renderers.